### PR TITLE
Add fake GBFS feed with rental URI

### DIFF
--- a/uri-demo/station_information.json
+++ b/uri-demo/station_information.json
@@ -2,9 +2,9 @@
   "data": {
     "stations": [
       {
-        "lat": 48.59449,
-        "lon": 8.86208,
-        "name": "Bhf. Herrenberg / Kalkofenstraße",
+        "lat": 48.59314,
+        "lon": 8.86644,
+        "name": "Demo Bike Station",
         "station_id": "7bd6d9cb-509b-4378-83db-cebb44ee1f6f2",
         "rental_uris": {
           "web":"https://www.abc.com/app?sid=1234567890"

--- a/uri-demo/station_information.json
+++ b/uri-demo/station_information.json
@@ -1,0 +1,17 @@
+{
+  "data": {
+    "stations": [
+      {
+        "lat": 48.59449,
+        "lon": 8.86208,
+        "name": "Bhf. Herrenberg / Kalkofenstraße",
+        "station_id": "7bd6d9cb-509b-4378-83db-cebb44ee1f6f2",
+        "rental_uris": {
+          "web":"https://www.abc.com/app?sid=1234567890"
+        }
+      }
+    ],
+    "last_updated": 1593510584,
+    "ttl": 60000
+  }
+}

--- a/uri-demo/station_status.json
+++ b/uri-demo/station_status.json
@@ -1,0 +1,13 @@
+{
+  "data": {
+    "stations": [
+      {
+        "num_bikes_available": 1,
+        "is_renting": true,
+        "station_id": "7bd6d9cb-509b-4378-83db-cebb44ee1f6f2"
+      }
+    ],
+    "last_updated": 1593510584,
+    "ttl": 60000
+  }
+}


### PR DESCRIPTION
Closes [#270](https://github.com/stadtnavi/digitransit-ui/issues/270)