### PR TITLE
Add free cargo bikes alf and fare

### DIFF
--- a/alf/gbfs.json
+++ b/alf/gbfs.json
@@ -1,0 +1,35 @@
+{
+  "last_updated": 1621036800,
+  "ttl": 86400,
+  "version": "2.2",
+  "data": {
+    "de": {
+      "feeds": [
+        {
+          "name": "system_information",
+          "url": "https://raw.githubusercontent.com/stadtnavi/static-gbfs-feeds/master/alf/system_information.json"
+        },
+        {
+          "name": "station_information",
+          "url": "https://raw.githubusercontent.com/stadtnavi/static-gbfs-feeds/master/alf/station_information.json"
+        },
+        {
+          "name": "station_status",
+          "url": "https://raw.githubusercontent.com/stadtnavi/static-gbfs-feeds/master/alf/station_status.json"
+        },
+        {
+          "name": "system_alerts",
+          "url": "https://raw.githubusercontent.com/stadtnavi/static-gbfs-feeds/master/alf/system_alerts.json"
+        },
+        {
+          "name": "system_hours",
+          "url": "https://raw.githubusercontent.com/stadtnavi/static-gbfs-feeds/master/alf/system_hours.json"
+        },
+        {
+          "name": "vehicle_types",
+          "url": "https://raw.githubusercontent.com/stadtnavi/static-gbfs-feeds/master/alf/vehicle_types.json"
+        }
+      ]
+    }
+  }
+}

--- a/alf/station_information.json
+++ b/alf/station_information.json
@@ -1,0 +1,24 @@
+{
+  "last_updated": 1621036800,
+  "ttl": 86400,
+  "version": "2.2",
+  "data": {
+    "stations": [
+      {
+        "lat": 48.60719,
+        "lon": 8.85903,
+        "name": "Lastenrad Alf",
+        "station_id": "alf",
+        "address": "Kaffeeberg 2",
+        "post_code": "70183",
+        "is_virtual_station": true,
+        "vehicle_type_capacity": {
+          "cargobike1": 1
+        },
+        "rental_uris": {
+          "web": "https://www.adfc-bw.de/boeblingen/startseite/news-einzeldarstellung/alf-eine-erfolgsgeschichte-aus-affstaett/"
+        }
+      }
+    ]
+  }
+}

--- a/alf/station_status.json
+++ b/alf/station_status.json
@@ -1,0 +1,20 @@
+{
+  "last_updated": 1621036800,
+  "ttl": 60,
+  "version": "2.2",
+  "data": {
+    "stations": [
+      {
+        "num_bikes_available": 1,
+        "is_installed": true,
+        "is_renting": true,
+        "is_returning": true,
+        "station_id": "alf",
+        "vehicle_types_available": [{
+          "vehicle_type_id": "cargobike1",
+          "count": 1
+        }]
+      }
+    ]
+  }
+}

--- a/alf/system_alerts.json
+++ b/alf/system_alerts.json
@@ -1,0 +1,9 @@
+{
+  "last_updated": 1621036800,
+  "ttl": 60,
+  "version": "2.2",
+  "data":{
+    "alerts":[
+    ]
+  }
+}

--- a/alf/system_hours.json
+++ b/alf/system_hours.json
@@ -1,0 +1,21 @@
+{
+  "last_updated": 1621036800,
+  "ttl": 86400,
+  "version": "2.2",
+  "data": {
+    "rental_hours": [
+      {
+        "user_types": [ "member" ],
+        "days": ["tue", "fri"],
+        "start_time": "10:00:00",
+        "end_time": "19:00:00"
+      },
+      {
+        "user_types": [ "member" ],
+        "days": ["wed", "thu"],
+        "start_time": "15:00:00",
+        "end_time": "19:00:00"
+      }
+    ]
+  }
+}

--- a/alf/system_information.json
+++ b/alf/system_information.json
@@ -1,0 +1,15 @@
+{
+  "last_updated": 1621036800,
+  "ttl": 86400,
+  "version": "2.2",
+  "data": {
+    "language": "DE",
+    "name": "ALF Lastenrad Affstätt",
+    "operator": "adfc Böblingen/Affstätter Bürgerschaft",
+    "system_id": "de.stadtnavi.gbfs.alf",
+    "timezone": "Europe/Berlin",
+    "url": "https://www.adfc-bw.de/boeblingen/",
+    "feed_contact_mail": "support@herrenberg.stadtnavi.de",
+    "mail": "alf-ausleihen@web.de"
+  },
+}

--- a/alf/vehicle_types.json
+++ b/alf/vehicle_types.json
@@ -1,0 +1,16 @@
+{
+  "last_updated": 1621036800,
+  "ttl": 86400,
+  "version": "2.2",
+  "data": {
+    "vehicle_types": [ 
+    	{
+	    	"name": "Lastenrad",
+	    	"vehicle_type_id": "cargobike1",
+	    	"form_factor": "cargo",
+	    	"max_range_meter": 25000,
+	    	"propulsion_type": "electric_assist"
+	    }
+	]
+  }
+}

--- a/bananologen/gbfs.json
+++ b/bananologen/gbfs.json
@@ -1,0 +1,35 @@
+{
+  "last_updated": 1621036800,
+  "ttl": 86400,
+  "version": "2.2",
+  "data": {
+    "de": {
+      "feeds": [
+        {
+          "name": "system_information",
+          "url": "https://raw.githubusercontent.com/stadtnavi/static-gbfs-feeds/master/bananologen/system_information.json"
+        },
+        {
+          "name": "station_information",
+          "url": "https://raw.githubusercontent.com/stadtnavi/static-gbfs-feeds/master/bananologen/station_information.json"
+        },
+        {
+          "name": "station_status",
+          "url": "https://raw.githubusercontent.com/stadtnavi/static-gbfs-feeds/master/bananologen/station_status.json"
+        },
+        {
+          "name": "system_alerts",
+          "url": "https://raw.githubusercontent.com/stadtnavi/static-gbfs-feeds/master/bananologen/system_alerts.json"
+        },
+        {
+          "name": "system_hours",
+          "url": "https://raw.githubusercontent.com/stadtnavi/static-gbfs-feeds/master/bananologen/system_hours.json"
+        },
+        {
+          "name": "vehicle_types",
+          "url": "https://raw.githubusercontent.com/stadtnavi/static-gbfs-feeds/master/bananologen/vehicle_types.json"
+        }
+      ]
+    }
+  }
+}

--- a/bananologen/station_information.json
+++ b/bananologen/station_information.json
@@ -1,0 +1,24 @@
+{
+  "last_updated": 1621036800,
+  "ttl": 86400,
+  "version": "2.2",
+  "data": {
+    "stations": [
+      {
+        "lat": 48.5961618,
+        "lon": 8.8701961,
+        "name": "E-Lastenrad FaRe",
+        "station_id": "fare",
+        "address": "Markthalle Herrenberg, Marktplatz 8",
+        "post_code": "70183",
+        "is_virtual_station": true,
+        "vehicle_type_capacity": {
+          "cargobike1": 1
+        },
+        "rental_uris": {
+          "web": "https://www.herrenberg.de/fairtrade"
+        }
+      }
+    ]
+  }
+}

--- a/bananologen/station_status.json
+++ b/bananologen/station_status.json
@@ -1,0 +1,20 @@
+{
+  "last_updated": 1621036800,
+  "ttl": 60,
+  "version": "2.2",
+  "data": {
+    "stations": [
+      {
+        "num_bikes_available": 1,
+        "is_installed": true,
+        "is_renting": true,
+        "is_returning": true,
+        "station_id": "fare",
+        "vehicle_types_available": [{
+          "vehicle_type_id": "cargobike1",
+          "count": 1
+        }]
+      }
+    ]
+  }
+}

--- a/bananologen/system_alerts.json
+++ b/bananologen/system_alerts.json
@@ -1,0 +1,9 @@
+{
+  "last_updated": 1621036800,
+  "ttl": 60,
+  "version": "2.2",
+  "data":{
+    "alerts":[
+    ]
+  }
+}

--- a/bananologen/system_hours.json
+++ b/bananologen/system_hours.json
@@ -1,0 +1,15 @@
+{
+  "last_updated": 1621036800,
+  "ttl": 86400,
+  "version": "2.2",
+  "data": {
+    "rental_hours": [
+      {
+        "user_types": [ "member" ],
+        "days": ["mon", "thu", "fri", "sat"],
+        "start_time": "09:00:00",
+        "end_time": "13:00:00"
+      }
+    ]
+  }
+}

--- a/bananologen/system_information.json
+++ b/bananologen/system_information.json
@@ -1,0 +1,15 @@
+{
+  "last_updated": 1621036800,
+  "ttl": 86400,
+  "version": "2.2",
+  "data": {
+    "language": "DE",
+    "name": "E-Lastenrad FaRe",
+    "operator": "Bananologen",
+    "system_id": "de.stadtnavi.gbfs.bananologen",
+    "timezone": "Europe/Berlin",
+    "url": "https://www.herrenberg.de/fairtrade",
+    "feed_contact_mail": "support@herrenberg.stadtnavi.de",
+    "mail": "bananologen@gmx.de"
+  },
+}

--- a/bananologen/vehicle_types.json
+++ b/bananologen/vehicle_types.json
@@ -1,0 +1,16 @@
+{
+  "last_updated": 1621036800,
+  "ttl": 86400,
+  "version": "2.2",
+  "data": {
+    "vehicle_types": [ 
+    	{
+	    	"name": "Lastenrad",
+	    	"vehicle_type_id": "cargobike1",
+	    	"form_factor": "cargo",
+	    	"max_range_meter": 25000,
+	    	"propulsion_type": "electric_assist"
+	    }
+	]
+  }
+}


### PR DESCRIPTION
ALF and FaRe are two free cargo bikes available in Herrenberg Affstätt (ALF) and Herrenberg city (FaRe) for which this PR adds static feeds